### PR TITLE
Fixing issues with AJAX properties

### DIFF
--- a/ESelect2.php
+++ b/ESelect2.php
@@ -67,9 +67,11 @@ class ESelect2 extends CInputWidget
 
             if ($this->hasModel()) {
                 echo CHtml::activeDropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions);
-            } else {
+            } elseif(!isset($this->options['ajax'])) {
                 $this->htmlOptions['id'] = $this->id;
                 echo CHtml::dropDownList($this->name, $this->value, $this->data, $this->htmlOptions);
+            } else {
+                echo CHtml::hiddenField($this->name, $this->value, $this->htmlOptions);
             }
         }
 


### PR DESCRIPTION
Allowing to load data with ajax requests.

Example:

Widget:

```
$this->widget('ext.ESelect2.ESelect2', array(
    'name' => 'choose-weapon',
    'options' => array(
        'minimumInputLength' => '3',
        'width' => '500px',
        'placeholder' => 'Select your Weapon',
        'ajax' => array(
            'url' => Yii::app()->controller->createUrl('inventory/searchWeapon'),
            'dataType' => 'json',
            'data' => 'js:function(term, page) { return {q: term }; }',
            'results' => 'js:function(data) { return {results: data}; }',
        ),
    ),
));
```

Controller: 

```
  public function actionSearchWeapon() {
        if (isset($_GET['q']))  {
                echo CJSON::encode(array('id' => '1', 'text' => 'My first Weapon')));
            }
        }
        Yii::app()->end();
    }
```
